### PR TITLE
fixed `igraph::as_data_frame` `what` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: supraHex
 Type: Package
 Title: supraHex: a supra-hexagonal map for analysing tabular omics data
-Version: 1.31.1
+Version: 1.31.2
 Date: 2021-5-24
 Author: Hai Fang and Julian Gough
 Maintainer: Hai Fang <hfang@well.ox.ac.uk>
@@ -29,17 +29,17 @@ Collate:
     sWriteData.r
     sMapOverlay.r
     visHexPattern.r
-    visHexGrid.r 
-    visHexMapping.r 
-    visHexComp.r 
-    visColormap.r 
-    visColorbar.r 
+    visHexGrid.r
+    visHexMapping.r
+    visHexComp.r
+    visColormap.r
+    visColorbar.r
     visVp.r
-    visHexMulComp.r 
+    visHexMulComp.r
     visHexAnimate.r
     visCompReorder.r
     visDmatCluster.r
-    visKernels.r 
+    visKernels.r
     visColoralpha.r
     visHeatmap.r
     visHeatmapAdv.r

--- a/R/sDmatCluster.r
+++ b/R/sDmatCluster.r
@@ -227,8 +227,8 @@ sDmatCluster <- function(sMap, which_neigh=1, distMeasure=c("mean","median","min
 		df_base <- tibble::tibble(index=seq(sMap$nHex), base=base, seed=vec_seed) %>% dplyr::bind_cols(tibble::as_tibble(sMap$coord))
 		
 		## df_edge for sMap$ig
-		df_edge <- sMap$ig %>% igraph::as_data_frame(what='edge') %>% tibble::as_tibble()
-		
+		df_edge <- sMap$ig %>% igraph::as_data_frame(what='edges') %>% tibble::as_tibble()
+
 		## df_edge_base
 		df_edge %>% dplyr::inner_join(df_base %>% dplyr::transmute(from=as.character(index), from_base=base), by='from') %>% dplyr::inner_join(df_base %>% dplyr::transmute(to=as.character(index), to_base=base), by='to') %>% dplyr::filter(from_base!=to_base) %>% dplyr::transmute(from_s=ifelse(from_base<to_base, from_base, to_base), to_l=ifelse(from_base<to_base, to_base, from_base)) %>% dplyr::distinct() -> df_edge_base
 		


### PR DESCRIPTION
Please merge this and propagate to Bioconductor `devel` (3.21) - This package still works, no reason to deprecate it, I got successful build & check after fixing this minor bug

See the latest Bioc build here: https://bioconductor.org/checkResults/devel/bioc-LATEST/supraHex/nebbiolo1-buildsrc.html